### PR TITLE
feat(images): Increase Discord file upload size limit and adjust image processing bias

### DIFF
--- a/crimsobot/data/img/rules.yaml
+++ b/crimsobot/data/img/rules.yaml
@@ -1,5 +1,5 @@
 image:
-  max_filesize: 8000000
+  max_filesize: 25000000
   msg_scrape_limit: 10
   url_contains:
     - .jpg

--- a/crimsobot/utils/image.py
+++ b/crimsobot/utils/image.py
@@ -739,7 +739,7 @@ async def process_image(ctx: Context, image: Optional[str], effect: str, arg: Op
 
         # recursively resize image until it meets Discord filesize limit
         img = Image.open(fp)
-        scale = 0.9 * IMAGE_RULES['max_filesize'] / n_bytes  # 0.9x bias to help ensure it comes in under max size
+        scale = 0.95 * IMAGE_RULES['max_filesize'] / n_bytes  # 0.95x bias to help ensure it comes in under max size
 
         fp = await process_lower_level(img, 'resize', scale)
         n_bytes = fp.getbuffer().nbytes


### PR DESCRIPTION
This PR addresses two issues related to image uploads in the crimsobot:

1.  **Increases Discord File Upload Size Limit:** The maximum file size for image uploads has been updated from 8MB to 25MB. This change aligns with Discord's recent increase for free users, allowing for higher-quality images to be uploaded.

2.  **Adjusts Image Processing Bias:** The bias in the `process_image` function's scaling variable has been increased by 0.05. This adjustment ensures that images are scaled down less aggressively, bringing them closer to the new 25MB file size limit without exceeding it.

These changes will improve the user experience by allowing for larger image uploads and better-quality processed images.